### PR TITLE
Speedometer refactor

### DIFF
--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -226,39 +226,13 @@ Color CHudSpeedometer::GetSpeedometerColor(
 {
 	int colorMode = hud_speedometer_color.GetInt();
 
-	int softCap = BHOP_CAP_SOFT * maxSpeed;
-	int midCap = BHOP_CAP_MID * maxSpeed;
-	int hardCap = BHOP_CAP_HARD * maxSpeed;
-
-	if (colorMode == 1) // Stepped
-	{
-		if (speed > hardCap)
-			return INTENSITYSCALE_COLOR_RED;
-		else if (speed > midCap)
-			return INTENSITYSCALE_COLOR_ORANGE;
-		else if (speed > softCap)
-			return INTENSITYSCALE_COLOR_YELLOW;
-		else if (speed > maxSpeed)
-			return INTENSITYSCALE_COLOR_GREEN;
-		else
-			return INTENSITYSCALE_COLOR_DEFAULT;
-	}
-	else if (colorMode == 2) // Fading
-	{
-		// only use yellow threshold for fading color mode
-		if (speed > hardCap)
-			return INTENSITYSCALE_COLOR_RED;
-		else if (speed > midCap)
-			return ColorFade(speed, midCap, hardCap, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
-		else if (speed > softCap)
-			return ColorFade(speed, softCap, midCap, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
-		else if (speed > maxSpeed)
-			return ColorFade(speed, maxSpeed, softCap, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
-		else
-			return INTENSITYSCALE_COLOR_DEFAULT;
-	}
-	else // No color
-	{
-		return INTENSITYSCALE_COLOR_DEFAULT;
-	}
+	return GetIntensityColor(
+		speed,
+		colorMode,
+		255,
+		BHOP_CAP_HARD * maxSpeed,
+		BHOP_CAP_MID * maxSpeed,
+		BHOP_CAP_SOFT * maxSpeed,
+		maxSpeed,
+		true);
 }

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -74,6 +74,8 @@ private:
 	unsigned int m_iNumUpdates;
 	float m_flNextUpdate;
 
+	Color GetSpeedometerColor(int speed, int maxSpeed);
+
 private:
 	// Stuff we need to know
 	CPanelAnimationVar(vgui::HFont, m_hSpeedFont, "SpeedFont", "HudNumbers");
@@ -164,28 +166,14 @@ void CHudSpeedometer::Paint()
 
 	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
 	float maxSpeed = pPlayer->MaxSpeed();
-	Color speedColor;
 
 	// regular speedometer
 	if (hud_speedometer.GetBool())
 	{
-		if (m_flSpeed > BHOP_CAP_HARD * maxSpeed && hud_speedometer_color.GetInt() > 0) // above hard cap
-			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if (m_flSpeed - 1 > BHOP_CAP_SOFT * maxSpeed && hud_speedometer_color.GetInt() > 0) // above soft cap
-			if (hud_speedometer_color.GetInt() == 2)
-				speedColor = ColorFade(m_flSpeed, BHOP_CAP_SOFT * maxSpeed, BHOP_CAP_HARD * maxSpeed, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
-			else
-				speedColor = INTENSITYSCALE_COLOR_ORANGE;
-		else if (m_flSpeed > maxSpeed && hud_speedometer_color.GetInt() > 0) // above max run speed
-			if (hud_speedometer_color.GetInt() == 2)
-				if (m_flSpeed > (maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade(m_flSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, BHOP_CAP_SOFT * maxSpeed, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
-				else
-					speedColor = ColorFade(m_flSpeed, maxSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
-			else
-				speedColor = INTENSITYSCALE_COLOR_GREEN;
-		else // below max run speed
-			speedColor = INTENSITYSCALE_COLOR_DEFAULT;
+		Color speedColor
+			= GetSpeedometerColor(
+				static_cast<int>(m_flSpeed),
+				static_cast<int>(maxSpeed));
 
 		surface()->DrawSetTextFont(m_hSpeedFont);
 		surface()->DrawSetTextColor(speedColor);
@@ -201,23 +189,10 @@ void CHudSpeedometer::Paint()
 	// average speedometer
 	if (hud_speedometer_avg.GetBool() && !isSpectating)
 	{
-		if (m_flAvgSpeed > BHOP_CAP_HARD * maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above hard cap
-			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if (m_flAvgSpeed - 1 > BHOP_CAP_SOFT * maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above soft cap
-			if (hud_speedometer_avg_color.GetInt() == 2)
-				speedColor = ColorFade(m_flAvgSpeed, BHOP_CAP_SOFT * maxSpeed, BHOP_CAP_HARD * maxSpeed, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
-			else
-				speedColor = INTENSITYSCALE_COLOR_ORANGE;
-		else if (m_flAvgSpeed > maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above max run speed
-			if (hud_speedometer_avg_color.GetInt() == 2)
-				if (m_flAvgSpeed > (maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade(m_flAvgSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, BHOP_CAP_SOFT * maxSpeed, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
-				else
-					speedColor = ColorFade(m_flAvgSpeed, maxSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
-			else
-				speedColor = INTENSITYSCALE_COLOR_GREEN;
-		else // below max run speed
-			speedColor = INTENSITYSCALE_COLOR_DEFAULT;
+		Color avgSpeedColor
+			= GetSpeedometerColor(
+				static_cast<int>(m_flAvgSpeed),
+				static_cast<int>(maxSpeed));
 
 		surface()->DrawSetTextFont(m_hAvgSpeedFont);
 		if (hud_speedometer.GetBool())
@@ -228,16 +203,58 @@ void CHudSpeedometer::Paint()
 		surface()->DrawSetTextColor(m_TextColor);
 
 		wchar_t textunicode[] = L"Average: ";
-
 		for (wchar_t* wch = textunicode; *wch != 0; wch++)
 			surface()->DrawUnicodeChar(*wch);
 
-		surface()->DrawSetTextColor(speedColor);
+		surface()->DrawSetTextColor(avgSpeedColor);
 
 		wchar_t unicode[6];
 		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_flAvgSpeed);
 
 		for (wchar_t* wch = unicode; *wch != 0; wch++)
 			surface()->DrawUnicodeChar(*wch);
+	}
+}
+
+Color CHudSpeedometer::GetSpeedometerColor(
+	int speed,
+	int maxSpeed)
+{
+	int colorMode = hud_speedometer_color.GetInt();
+
+	int softCap = BHOP_CAP_SOFT * maxSpeed;
+	int midCap = BHOP_CAP_MID * maxSpeed;
+	int hardCap = BHOP_CAP_HARD * maxSpeed;
+
+	if (colorMode == 1) // Stepped
+	{
+		if (speed > hardCap)
+			return INTENSITYSCALE_COLOR_RED;
+		else if (speed > midCap)
+			return INTENSITYSCALE_COLOR_ORANGE;
+		else if (speed > softCap)
+			return INTENSITYSCALE_COLOR_YELLOW;
+		else if (speed > maxSpeed)
+			return INTENSITYSCALE_COLOR_GREEN;
+		else
+			return INTENSITYSCALE_COLOR_DEFAULT;
+	}
+	else if (colorMode == 2) // Fading
+	{
+		// only use yellow threshold for fading color mode
+		if (speed > hardCap)
+			return INTENSITYSCALE_COLOR_RED;
+		else if (speed > midCap)
+			return ColorFade(speed, midCap, hardCap, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
+		else if (speed > softCap)
+			return ColorFade(speed, softCap, midCap, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
+		else if (speed > maxSpeed)
+			return ColorFade(speed, maxSpeed, softCap, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
+		else
+			return INTENSITYSCALE_COLOR_DEFAULT;
+	}
+	else // No color
+	{
+		return INTENSITYSCALE_COLOR_DEFAULT;
 	}
 }

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -69,11 +69,9 @@ public:
 	virtual void Paint();
 
 private:
-	// ELMO ***
-	float m_flAvgVelocity;
+	float m_flAvgSpeed;
+	float m_flSpeed;
 	unsigned int m_iNumUpdates;
-	int m_iVelocity;
-	// *** ELMO
 	float m_flNextUpdate;
 
 private:
@@ -104,7 +102,7 @@ void CHudSpeedometer::Init(void)
 void CHudSpeedometer::VidInit(void)
 {
 	Reset();
-	m_flAvgVelocity = 0.0;
+	m_flAvgSpeed = 0.0;
 	m_iNumUpdates = 0;
 }
 
@@ -135,14 +133,14 @@ void CHudSpeedometer::OnThink()
 	if (m_flNextUpdate < gpGlobals->curtime)
 	{
 		Vector vecVelocity = pPlayer->GetAbsVelocity();
-		m_iVelocity = (int)FastSqrt(
+		m_flSpeed = FastSqrt(
 			vecVelocity.x * vecVelocity.x
 			+ vecVelocity.y * vecVelocity.y);
 
 		if (!isSpectating)
 		{
 			// average[i+1] = (average[i]*i + value[i+1])/(i+1)
-			m_flAvgVelocity = (m_flAvgVelocity * m_iNumUpdates + (float)m_iVelocity) / (m_iNumUpdates + 1);
+			m_flAvgSpeed = (m_flAvgSpeed * m_iNumUpdates + m_flSpeed) / (m_iNumUpdates + 1);
 			m_iNumUpdates++;
 		}
 
@@ -165,25 +163,25 @@ void CHudSpeedometer::Paint()
 		return;
 
 	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
-	float maxVelocity = pPlayer->MaxSpeed();
+	float maxSpeed = pPlayer->MaxSpeed();
 	Color speedColor;
 
 	// regular speedometer
 	if (hud_speedometer.GetBool())
 	{
-		if (m_iVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_color.GetInt() > 0) // above hard cap
+		if (m_flSpeed > BHOP_CAP_HARD * maxSpeed && hud_speedometer_color.GetInt() > 0) // above hard cap
 			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if (m_iVelocity - 1 > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_color.GetInt() > 0) // above soft cap
+		else if (m_flSpeed - 1 > BHOP_CAP_SOFT * maxSpeed && hud_speedometer_color.GetInt() > 0) // above soft cap
 			if (hud_speedometer_color.GetInt() == 2)
-				speedColor = ColorFade(m_iVelocity, BHOP_CAP_SOFT * maxVelocity, BHOP_CAP_HARD * maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
+				speedColor = ColorFade(m_flSpeed, BHOP_CAP_SOFT * maxSpeed, BHOP_CAP_HARD * maxSpeed, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
 			else
 				speedColor = INTENSITYSCALE_COLOR_ORANGE;
-		else if (m_iVelocity > maxVelocity && hud_speedometer_color.GetInt() > 0) // above max run speed
+		else if (m_flSpeed > maxSpeed && hud_speedometer_color.GetInt() > 0) // above max run speed
 			if (hud_speedometer_color.GetInt() == 2)
-				if (m_iVelocity > (maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade(m_iVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, BHOP_CAP_SOFT * maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
+				if (m_flSpeed > (maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
+					speedColor = ColorFade(m_flSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, BHOP_CAP_SOFT * maxSpeed, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
 				else
-					speedColor = ColorFade(m_iVelocity, maxVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
+					speedColor = ColorFade(m_flSpeed, maxSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
 			else
 				speedColor = INTENSITYSCALE_COLOR_GREEN;
 		else // below max run speed
@@ -194,7 +192,7 @@ void CHudSpeedometer::Paint()
 		surface()->DrawSetTextPos(SpeedFont_xpos, SpeedFont_ypos);
 
 		wchar_t unicode[6];
-		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_iVelocity);
+		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_flSpeed);
 
 		for (wchar_t* wch = unicode; *wch != 0; wch++)
 			surface()->DrawUnicodeChar(*wch);
@@ -203,19 +201,19 @@ void CHudSpeedometer::Paint()
 	// average speedometer
 	if (hud_speedometer_avg.GetBool() && !isSpectating)
 	{
-		if (m_flAvgVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above hard cap
+		if (m_flAvgSpeed > BHOP_CAP_HARD * maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above hard cap
 			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if (m_flAvgVelocity - 1 > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above soft cap
+		else if (m_flAvgSpeed - 1 > BHOP_CAP_SOFT * maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above soft cap
 			if (hud_speedometer_avg_color.GetInt() == 2)
-				speedColor = ColorFade(m_flAvgVelocity, BHOP_CAP_SOFT * maxVelocity, BHOP_CAP_HARD * maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
+				speedColor = ColorFade(m_flAvgSpeed, BHOP_CAP_SOFT * maxSpeed, BHOP_CAP_HARD * maxSpeed, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
 			else
 				speedColor = INTENSITYSCALE_COLOR_ORANGE;
-		else if (m_flAvgVelocity > maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above max run speed
+		else if (m_flAvgSpeed > maxSpeed && hud_speedometer_avg_color.GetInt() > 0) // above max run speed
 			if (hud_speedometer_avg_color.GetInt() == 2)
-				if (m_flAvgVelocity > (maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade(m_flAvgVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, BHOP_CAP_SOFT * maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
+				if (m_flAvgSpeed > (maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
+					speedColor = ColorFade(m_flAvgSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, BHOP_CAP_SOFT * maxSpeed, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
 				else
-					speedColor = ColorFade(m_flAvgVelocity, maxVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
+					speedColor = ColorFade(m_flAvgSpeed, maxSpeed, maxSpeed + 3 * (BHOP_CAP_SOFT * maxSpeed - maxSpeed) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
 			else
 				speedColor = INTENSITYSCALE_COLOR_GREEN;
 		else // below max run speed
@@ -237,7 +235,7 @@ void CHudSpeedometer::Paint()
 		surface()->DrawSetTextColor(speedColor);
 
 		wchar_t unicode[6];
-		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_flAvgVelocity);
+		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_flAvgSpeed);
 
 		for (wchar_t* wch = unicode; *wch != 0; wch++)
 			surface()->DrawUnicodeChar(*wch);

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -64,10 +64,10 @@ public:
 private:
 	float m_flAvgSpeed;
 	float m_flSpeed;
-	unsigned int m_iNumUpdates;
 	float m_flNextUpdate;
 
 	Color GetSpeedometerColor(int speed, int maxSpeed);
+	float AlphaForTarget(float p, float T, float dt);
 
 private:
 	// Stuff we need to know
@@ -97,8 +97,7 @@ void CHudSpeedometer::Init(void)
 void CHudSpeedometer::VidInit(void)
 {
 	Reset();
-	m_flAvgSpeed = 0.0;
-	m_iNumUpdates = 0;
+	m_flAvgSpeed = 0.0f;
 }
 
 //-----------------------------------------------------------------------------
@@ -117,31 +116,44 @@ void CHudSpeedometer::OnThink()
 	if (!hud_speedometer.GetBool() && !hud_speedometer_avg.GetBool())
 		return;
 
-	C_FFPlayer* pPlayer = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
+	C_FFPlayer* pPlayer
+		= C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
 
 	if (!pPlayer)
 		return;
 
-	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
+	if (gpGlobals->curtime < m_flNextUpdate) {
+		return;
+	}
 
-	//don't update so fast.
-	if (m_flNextUpdate < gpGlobals->curtime)
-	{
-		Vector vecVelocity = pPlayer->GetAbsVelocity();
-		m_flSpeed = FastSqrt(
+	Vector vecVelocity
+		= pPlayer->GetAbsVelocity();
+
+	m_flSpeed
+		= FastSqrt(
 			vecVelocity.x * vecVelocity.x
 			+ vecVelocity.y * vecVelocity.y);
 
-		if (!isSpectating)
-		{
-			// average[i+1] = (average[i]*i + value[i+1])/(i+1)
-			m_flAvgSpeed = (m_flAvgSpeed * m_iNumUpdates + m_flSpeed) / (m_iNumUpdates + 1);
-			m_iNumUpdates++;
-		}
+	const float dt = 0.1f;     // your m_flNextUpdate step
+	const float p = 0.8f;      // 80% responsiveness
+	const float T = 1.0f;      // within 1 second
+	const float alpha          // 0.14866
+		= AlphaForTarget(p, T, dt);
 
-		m_flNextUpdate = gpGlobals->curtime + 0.1;
-	}
+	m_flAvgSpeed
+		= alpha * m_flSpeed
+		+ (1.0f - alpha) * m_flAvgSpeed;
 
+	m_flNextUpdate = gpGlobals->curtime + dt;
+}
+
+// Pick alpha to hit fraction p (e.g. 0.8) by time T, given update step dt.
+float CHudSpeedometer::AlphaForTarget(float p, float T, float dt) {
+	// Clamp to safe ranges
+	if (p <= 0.0f) return 0.0f;
+	if (p >= 1.0f) return 1.0f;
+	if (dt <= 0.0f) return 1.0f;
+	return 1.0f - powf(1.0f - p, dt / T);
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -13,7 +13,7 @@
 #include "iclientvehicle.h"
 #include "ammodef.h"
 #include "ff_utils.h"
-#include "ff_shareddefs.h" //added to use colors stored within!
+#include "ff_shareddefs.h"
 
 #include <KeyValues.h>
 #include <vgui/ISurface.h>
@@ -24,12 +24,6 @@
 
 #include <vgui/ILocalize.h>
 
-// ELMO *** 
-#define BHOP_CAP_SOFT 1.4f // as defined in ff_gamemovement.cpp
-#define BHOP_CAP_MID 1.55f // as defined in ff_gamemovement.cpp
-#define BHOP_CAP_HARD 1.71f // as defined in ff_gamemovement.cpp
-// *** ELMO
-
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -37,7 +31,6 @@ using namespace vgui;
 
 static ConVar hud_speedometer("hud_speedometer", "1", FCVAR_ARCHIVE, "Toggle speedometer. Disclaimer: We are not responsible if you get a ticket.");
 static ConVar hud_speedometer_avg("hud_speedometer_avg", "0", FCVAR_ARCHIVE, "Toggle average speedometer.");
-// ELMO *** 
 static ConVar hud_speedometer_color("hud_speedometer_color", "2", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
 static ConVar hud_speedometer_avg_color("hud_speedometer_avg_color", "0", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
 

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -1,6 +1,6 @@
 //========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
 //
-// Purpose: 
+// Purpose:
 //
 //=============================================================================//
 
@@ -35,13 +35,13 @@
 
 using namespace vgui;
 
-static ConVar hud_speedometer( "hud_speedometer", "1", FCVAR_ARCHIVE, "Toggle speedometer. Disclaimer: We are not responsible if you get a ticket.");
-static ConVar hud_speedometer_avg( "hud_speedometer_avg", "0", FCVAR_ARCHIVE, "Toggle average speedometer.");
+static ConVar hud_speedometer("hud_speedometer", "1", FCVAR_ARCHIVE, "Toggle speedometer. Disclaimer: We are not responsible if you get a ticket.");
+static ConVar hud_speedometer_avg("hud_speedometer_avg", "0", FCVAR_ARCHIVE, "Toggle average speedometer.");
 // ELMO *** 
-static ConVar hud_speedometer_color( "hud_speedometer_color", "2", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
-static ConVar hud_speedometer_avg_color( "hud_speedometer_avg_color", "0", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
+static ConVar hud_speedometer_color("hud_speedometer_color", "2", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
+static ConVar hud_speedometer_avg_color("hud_speedometer_avg_color", "0", FCVAR_ARCHIVE, "0=No color, 1=Stepped Color, 2=Fading Color (RED > hardcap :: ORANGE > softcap :: GREEN > run speed :: WHITE < run speed)", true, 0.0f, true, 2.0f);
 
-Color ColorFade( int currentVal, int minVal, int maxVal, Color minColor, Color maxColor );
+Color ColorFade(int currentVal, int minVal, int maxVal, Color minColor, Color maxColor);
 
 //-----------------------------------------------------------------------------
 // Purpose: Displays current disguised class
@@ -49,51 +49,51 @@ Color ColorFade( int currentVal, int minVal, int maxVal, Color minColor, Color m
 class CHudSpeedometer : public CHudElement, public vgui::FFPanel
 {
 public:
-	DECLARE_CLASS_SIMPLE( CHudSpeedometer, vgui::FFPanel );
+	DECLARE_CLASS_SIMPLE(CHudSpeedometer, vgui::FFPanel);
 
-	CHudSpeedometer( const char *pElementName ) : vgui::FFPanel( NULL, "HudSpeedometer" ), CHudElement( pElementName )
+	CHudSpeedometer(const char* pElementName) : vgui::FFPanel(NULL, "HudSpeedometer"), CHudElement(pElementName)
 	{
-		SetParent( g_pClientMode->GetViewport() );
-		SetHiddenBits( HIDEHUD_PLAYERDEAD | HIDEHUD_UNASSIGNED );
+		SetParent(g_pClientMode->GetViewport());
+		SetHiddenBits(HIDEHUD_PLAYERDEAD | HIDEHUD_UNASSIGNED);
 	}
 
-	virtual ~CHudSpeedometer( void )
+	virtual ~CHudSpeedometer(void)
 	{
 
 	}
 
-	virtual void Init( void );
-	virtual void VidInit( void );
-	virtual void Reset( void );
+	virtual void Init(void);
+	virtual void VidInit(void);
+	virtual void Reset(void);
 	virtual void OnThink();
 	virtual void Paint();
 
 private:
-// ELMO ***
+	// ELMO ***
 	float m_flAvgVelocity;
 	unsigned int m_iNumUpdates;
 	int m_iVelocity;
-// *** ELMO
+	// *** ELMO
 	float m_flNextUpdate;
 
 private:
-	// Stuff we need to know	
-	CPanelAnimationVar( vgui::HFont, m_hSpeedFont, "SpeedFont", "HudNumbers" );
-	CPanelAnimationVar( vgui::HFont, m_hAvgSpeedFont, "AvgSpeedFont", "Default" );
-	CPanelAnimationVar( Color, m_TextColor, "TextColor", "HUD_Tone_Default" );
+	// Stuff we need to know
+	CPanelAnimationVar(vgui::HFont, m_hSpeedFont, "SpeedFont", "HudNumbers");
+	CPanelAnimationVar(vgui::HFont, m_hAvgSpeedFont, "AvgSpeedFont", "Default");
+	CPanelAnimationVar(Color, m_TextColor, "TextColor", "HUD_Tone_Default");
 
-	CPanelAnimationVarAliasType( float, SpeedFont_xpos, "SpeedFont_xpos", "0", "proportional_float" );
-	CPanelAnimationVarAliasType( float, SpeedFont_ypos, "SpeedFont_ypos", "0", "proportional_float" );
-	CPanelAnimationVarAliasType( float, AvgSpeedFont_xpos, "AvgSpeedFont_xpos", "0", "proportional_float" );
-	CPanelAnimationVarAliasType( float, AvgSpeedFont_ypos, "AvgSpeedFont_ypos", "0", "proportional_float" );
+	CPanelAnimationVarAliasType(float, SpeedFont_xpos, "SpeedFont_xpos", "0", "proportional_float");
+	CPanelAnimationVarAliasType(float, SpeedFont_ypos, "SpeedFont_ypos", "0", "proportional_float");
+	CPanelAnimationVarAliasType(float, AvgSpeedFont_xpos, "AvgSpeedFont_xpos", "0", "proportional_float");
+	CPanelAnimationVarAliasType(float, AvgSpeedFont_ypos, "AvgSpeedFont_ypos", "0", "proportional_float");
 };
 
-DECLARE_HUDELEMENT( CHudSpeedometer );
+DECLARE_HUDELEMENT(CHudSpeedometer);
 
 //-----------------------------------------------------------------------------
 // Purpose: Done on loading game?
 //-----------------------------------------------------------------------------
-void CHudSpeedometer::Init( void )
+void CHudSpeedometer::Init(void)
 {
 	Reset();
 }
@@ -101,7 +101,7 @@ void CHudSpeedometer::Init( void )
 //-----------------------------------------------------------------------------
 // Purpose: Done each map load
 //-----------------------------------------------------------------------------
-void CHudSpeedometer::VidInit( void )
+void CHudSpeedometer::VidInit(void)
 {
 	Reset();
 	m_flAvgVelocity = 0.0;
@@ -109,7 +109,7 @@ void CHudSpeedometer::VidInit( void )
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: 
+// Purpose:
 //-----------------------------------------------------------------------------
 void CHudSpeedometer::Reset()
 {
@@ -119,127 +119,127 @@ void CHudSpeedometer::Reset()
 //-----------------------------------------------------------------------------
 // Purpose: Should we draw? (Are we ingame? have we picked a class, etc)
 //-----------------------------------------------------------------------------
-void CHudSpeedometer::OnThink() 
-{ 
+void CHudSpeedometer::OnThink()
+{
 	if (!hud_speedometer.GetBool() && !hud_speedometer_avg.GetBool())
 		return;
 
-	C_FFPlayer *pPlayer = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
+	C_FFPlayer* pPlayer = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
 
-	if(!pPlayer)
+	if (!pPlayer)
 		return;
 
-	bool isSpectating = FF_IsPlayerSpec( C_FFPlayer::GetLocalFFPlayer() );
+	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
 
 	//don't update so fast.
-	if(m_flNextUpdate < gpGlobals->curtime)
+	if (m_flNextUpdate < gpGlobals->curtime)
 	{
 		Vector vecVelocity = pPlayer->GetAbsVelocity();
-		m_iVelocity = (int) FastSqrt(
-			vecVelocity.x * vecVelocity.x 
-			+ vecVelocity.y * vecVelocity.y );
+		m_iVelocity = (int)FastSqrt(
+			vecVelocity.x * vecVelocity.x
+			+ vecVelocity.y * vecVelocity.y);
 
 		if (!isSpectating)
 		{
 			// average[i+1] = (average[i]*i + value[i+1])/(i+1)
-			m_flAvgVelocity = (m_flAvgVelocity*m_iNumUpdates + (float)m_iVelocity)/(m_iNumUpdates+1);
+			m_flAvgVelocity = (m_flAvgVelocity * m_iNumUpdates + (float)m_iVelocity) / (m_iNumUpdates + 1);
 			m_iNumUpdates++;
 		}
 
 		m_flNextUpdate = gpGlobals->curtime + 0.1;
 	}
-	
-} 
+
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: Draw stuff!
 //-----------------------------------------------------------------------------
-void CHudSpeedometer::Paint() 
+void CHudSpeedometer::Paint()
 {
 	if (!hud_speedometer.GetBool() && !hud_speedometer_avg.GetBool())
 		return;
 
-	C_FFPlayer *pPlayer = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
+	C_FFPlayer* pPlayer = C_FFPlayer::GetLocalFFPlayerOrAnyObserverTarget();
 
-	if(!pPlayer)
+	if (!pPlayer)
 		return;
 
-	bool isSpectating = FF_IsPlayerSpec( C_FFPlayer::GetLocalFFPlayer() );
+	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
 	float maxVelocity = pPlayer->MaxSpeed();
 	Color speedColor;
 
 	// regular speedometer
-	if( hud_speedometer.GetBool() )
+	if (hud_speedometer.GetBool())
 	{
-		if( m_iVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_color.GetInt() > 0) // above hard cap
+		if (m_iVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_color.GetInt() > 0) // above hard cap
 			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if(m_iVelocity-1  > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_color.GetInt() > 0) // above soft cap
-			if(hud_speedometer_color.GetInt() == 2)
-				speedColor = ColorFade( m_iVelocity, BHOP_CAP_SOFT*maxVelocity, BHOP_CAP_HARD*maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED );
+		else if (m_iVelocity - 1 > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_color.GetInt() > 0) // above soft cap
+			if (hud_speedometer_color.GetInt() == 2)
+				speedColor = ColorFade(m_iVelocity, BHOP_CAP_SOFT * maxVelocity, BHOP_CAP_HARD * maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
 			else
-				speedColor = INTENSITYSCALE_COLOR_ORANGE;	
-		else if( m_iVelocity > maxVelocity && hud_speedometer_color.GetInt() > 0) // above max run speed
-			if(hud_speedometer_color.GetInt() == 2)
-				if( m_iVelocity > (maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade( m_iVelocity, maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4, BHOP_CAP_SOFT*maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE );
+				speedColor = INTENSITYSCALE_COLOR_ORANGE;
+		else if (m_iVelocity > maxVelocity && hud_speedometer_color.GetInt() > 0) // above max run speed
+			if (hud_speedometer_color.GetInt() == 2)
+				if (m_iVelocity > (maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
+					speedColor = ColorFade(m_iVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, BHOP_CAP_SOFT * maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
 				else
-					speedColor = ColorFade( m_iVelocity, maxVelocity, maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW );
+					speedColor = ColorFade(m_iVelocity, maxVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
 			else
 				speedColor = INTENSITYSCALE_COLOR_GREEN;
 		else // below max run speed
 			speedColor = INTENSITYSCALE_COLOR_DEFAULT;
 
-		surface()->DrawSetTextFont( m_hSpeedFont );
-		surface()->DrawSetTextColor( speedColor );
-		surface()->DrawSetTextPos( SpeedFont_xpos, SpeedFont_ypos );
+		surface()->DrawSetTextFont(m_hSpeedFont);
+		surface()->DrawSetTextColor(speedColor);
+		surface()->DrawSetTextPos(SpeedFont_xpos, SpeedFont_ypos);
 
 		wchar_t unicode[6];
 		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_iVelocity);
 
-		for( wchar_t *wch = unicode; *wch != 0; wch++ )
-			surface()->DrawUnicodeChar( *wch );
+		for (wchar_t* wch = unicode; *wch != 0; wch++)
+			surface()->DrawUnicodeChar(*wch);
 	}
 
 	// average speedometer
-	if( hud_speedometer_avg.GetBool() && !isSpectating )
+	if (hud_speedometer_avg.GetBool() && !isSpectating)
 	{
-		if( m_flAvgVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above hard cap
+		if (m_flAvgVelocity > BHOP_CAP_HARD * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above hard cap
 			speedColor = INTENSITYSCALE_COLOR_RED;
-		else if(m_flAvgVelocity-1  > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above soft cap
-			if(hud_speedometer_avg_color.GetInt() == 2)
-				speedColor = ColorFade( m_flAvgVelocity, BHOP_CAP_SOFT*maxVelocity, BHOP_CAP_HARD*maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED );
+		else if (m_flAvgVelocity - 1 > BHOP_CAP_SOFT * maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above soft cap
+			if (hud_speedometer_avg_color.GetInt() == 2)
+				speedColor = ColorFade(m_flAvgVelocity, BHOP_CAP_SOFT * maxVelocity, BHOP_CAP_HARD * maxVelocity, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_RED);
 			else
-				speedColor = INTENSITYSCALE_COLOR_ORANGE;	
-		else if( m_flAvgVelocity > maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above max run speed
-			if(hud_speedometer_avg_color.GetInt() == 2)
-				if( m_flAvgVelocity > (maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4) && hud_speedometer_color.GetInt() > 0) // above max run speed
-					speedColor = ColorFade( m_flAvgVelocity, maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4, BHOP_CAP_SOFT*maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE );
+				speedColor = INTENSITYSCALE_COLOR_ORANGE;
+		else if (m_flAvgVelocity > maxVelocity && hud_speedometer_avg_color.GetInt() > 0) // above max run speed
+			if (hud_speedometer_avg_color.GetInt() == 2)
+				if (m_flAvgVelocity > (maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4) && hud_speedometer_color.GetInt() > 0) // above max run speed
+					speedColor = ColorFade(m_flAvgVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, BHOP_CAP_SOFT * maxVelocity, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_ORANGE);
 				else
-					speedColor = ColorFade( m_flAvgVelocity, maxVelocity, maxVelocity+3*(BHOP_CAP_SOFT*maxVelocity - maxVelocity)/4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW );
+					speedColor = ColorFade(m_flAvgVelocity, maxVelocity, maxVelocity + 3 * (BHOP_CAP_SOFT * maxVelocity - maxVelocity) / 4, INTENSITYSCALE_COLOR_GREEN, INTENSITYSCALE_COLOR_YELLOW);
 			else
 				speedColor = INTENSITYSCALE_COLOR_GREEN;
 		else // below max run speed
 			speedColor = INTENSITYSCALE_COLOR_DEFAULT;
 
-		surface()->DrawSetTextFont( m_hAvgSpeedFont );
+		surface()->DrawSetTextFont(m_hAvgSpeedFont);
 		if (hud_speedometer.GetBool())
-			surface()->DrawSetTextPos( AvgSpeedFont_xpos, AvgSpeedFont_ypos );
+			surface()->DrawSetTextPos(AvgSpeedFont_xpos, AvgSpeedFont_ypos);
 		else
-			surface()->DrawSetTextPos( AvgSpeedFont_xpos, AvgSpeedFont_ypos + SpeedFont_ypos );
+			surface()->DrawSetTextPos(AvgSpeedFont_xpos, AvgSpeedFont_ypos + SpeedFont_ypos);
 
-		surface()->DrawSetTextColor( m_TextColor );
+		surface()->DrawSetTextColor(m_TextColor);
 
 		wchar_t textunicode[] = L"Average: ";
 
-		for( wchar_t *wch = textunicode; *wch != 0; wch++ )
-			surface()->DrawUnicodeChar( *wch );
+		for (wchar_t* wch = textunicode; *wch != 0; wch++)
+			surface()->DrawUnicodeChar(*wch);
 
-		surface()->DrawSetTextColor( speedColor );
+		surface()->DrawSetTextColor(speedColor);
 
 		wchar_t unicode[6];
 		V_snwprintf(unicode, ARRAYSIZE(unicode), L"%d", (int)m_flAvgVelocity);
 
-		for( wchar_t *wch = unicode; *wch != 0; wch++ )
-			surface()->DrawUnicodeChar( *wch );
+		for (wchar_t* wch = unicode; *wch != 0; wch++)
+			surface()->DrawUnicodeChar(*wch);
 	}
 }

--- a/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
+++ b/mp/src/game/client/ff/hud/ff_hud_speedometer.cpp
@@ -169,7 +169,6 @@ void CHudSpeedometer::Paint()
 	if (!pPlayer)
 		return;
 
-	bool isSpectating = FF_IsPlayerSpec(C_FFPlayer::GetLocalFFPlayer());
 	float maxSpeed = pPlayer->MaxSpeed();
 
 	// regular speedometer
@@ -192,7 +191,7 @@ void CHudSpeedometer::Paint()
 	}
 
 	// average speedometer
-	if (hud_speedometer_avg.GetBool() && !isSpectating)
+	if (hud_speedometer_avg.GetBool())
 	{
 		Color avgSpeedColor
 			= GetSpeedometerColor(

--- a/mp/src/game/client/game_controls/classmenu.cpp
+++ b/mp/src/game/client/game_controls/classmenu.cpp
@@ -240,7 +240,7 @@ public:
 	{
 		m_pProgressBar->SetProgress( clamp( m_flValue / m_flMax, 0.0f, 1.0f ) );
 		m_pProgressBar->SetBgColor( Color( 0,0,0, 100 ) );
-		m_pProgressBar->SetFgColor( GetIntensityColor((int)(m_flValue/m_flMax * 100), 255, 2, 100, 25, 50, 70, 90) );
+		m_pProgressBar->SetFgColor( GetIntensityColor((int)(m_flValue/m_flMax * 100), 2, 100, 25, 50, 75, 100) );
 
 		BaseClass::Paint();
 	}

--- a/mp/src/game/shared/ff/ff_gamemovement.cpp
+++ b/mp/src/game/shared/ff/ff_gamemovement.cpp
@@ -90,17 +90,6 @@ public:
 	CFFGameMovement() {};
 };
 
-//static ConVar bhop_cap_soft("ffdev_bhop_cap_soft", "1.4", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_soft.GetFloat()
-#define BHOP_CAP_SOFT 1.4f // also defined in ff_hud_speedometer - change it there too! 
-//static ConVar bhop_cap_mid("ffdev_bhop_cap_mid", "1.55", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_mid.GetFloat()
-#define BHOP_CAP_MID 1.55f //bhop_cap_mid.GetFloat() // also defined in ff_hud_speedometer - change it there too! // This slows the player more if they go above this cap
-//static ConVar bhop_cap_hard("ffdev_bhop_cap_hard", "1.71", FCVAR_FF_FFDEV_REPLICATED); // bhop_cap_hard.GetFloat()
-#define BHOP_CAP_HARD 1.71f // also defined in ff_hud_speedometer - change it there too!
-//static ConVar bhop_pcfactor("ffdev_bhop_pcfactor", "0.65", FCVAR_FF_FFDEV_REPLICATED); // bhop_pcfactor.GetFloat()
-#define BHOP_PCFACTOR 0.65f //bhop_pcfactor.GetFloat()
-//static ConVar bhop_pcfactor_mid("ffdev_bhop_pcfactor_mid", "0.4", FCVAR_FF_FFDEV_REPLICATED); // bhop_pcfactor_mid.GetFloat()
-#define BHOP_PCFACTOR_MID 0.4f //bhop_pcfactor_mid.GetFloat()
-
 //-----------------------------------------------------------------------------
 // Purpose: Provides TFC jump heights, trimping, doublejumps
 //-----------------------------------------------------------------------------

--- a/mp/src/game/shared/ff/ff_shareddefs.h
+++ b/mp/src/game/shared/ff/ff_shareddefs.h
@@ -1,6 +1,6 @@
 //========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
-// Purpose: 
+// Purpose:
 //
 //=============================================================================//
 
@@ -144,6 +144,12 @@ struct SpyDisguiseWeapon
 #define DECAP_RIGHT_ARM		( 1 << 2 )
 #define DECAP_LEFT_LEG		( 1 << 3 )
 #define DECAP_RIGHT_LEG		( 1 << 4 )
+
+#define BHOP_CAP_SOFT 1.4f
+#define BHOP_CAP_MID 1.55f
+#define BHOP_CAP_HARD 1.71f
+#define BHOP_PCFACTOR 0.65f
+#define BHOP_PCFACTOR_MID 0.4f
 
 // HUD Definitions
 #define INTENSITYSCALE_COLOR_RED Color(255,0,0,255)

--- a/mp/src/game/shared/ff/ff_utils.cpp
+++ b/mp/src/game/shared/ff/ff_utils.cpp
@@ -288,53 +288,108 @@ const char *FF_GetDefaultWeapon( const char *classname )
 	return FF_GetDefaultWeapon( Class_StringToInt( classname ) );
 }
 
-Color ColorFade( int iValue, int iMin, int iMax, Color clrMin, Color clrMax )
+Color ColorFade(
+	int iValue,
+	int iLimit0,
+	int iLimit1,
+	Color clrMin,
+	Color clrMax,
+	bool bInvert)
 {
+	int iMin = min(iLimit0, iLimit1);
+	int iMax = max(iLimit0, iLimit1);
 	int iClamped = clamp(iValue, iMin, iMax);
 
 	float flRange = iMax - iMin;
-	float flMinAmount = (iMax - iClamped) / flRange;
-	float flMaxAmount = (iClamped - iMin) / flRange;
+
+	// Avoid divide by zero
+	if (flRange <= 0.0f)
+		return bInvert ? clrMin : clrMax;
+
+	float flFadeAmount
+		= (float)(iClamped - iMin)
+		/ flRange;
+
+	// Invert the color fade if needed
+	if (bInvert)
+		flFadeAmount = 1.0f - flFadeAmount;
 
 	return Color(
-		(int) (clrMax.r() * flMaxAmount + clrMin.r() * flMinAmount),
-		(int) (clrMax.g() * flMaxAmount + clrMin.g() * flMinAmount),
-		(int) (clrMax.b() * flMaxAmount + clrMin.b() * flMinAmount),
-		(int) (clrMax.a() * flMaxAmount + clrMin.a() * flMinAmount));
+		(int)(clrMin.r() + (clrMax.r() - clrMin.r()) * flFadeAmount),
+		(int)(clrMin.g() + (clrMax.g() - clrMin.g()) * flFadeAmount),
+		(int)(clrMin.b() + (clrMax.b() - clrMin.b()) * flFadeAmount),
+		(int)(clrMin.a() + (clrMax.a() - clrMin.a()) * flFadeAmount));
 }
 
-Color GetIntensityColor( int iAmount, int iMaxAmount, int iColorSetting, int iAlpha, int iRed, int iOrange, int iYellow, int iGreen )
+Color GetIntensityColor(
+	int iValue,
+	int iColorMode,
+	int iAlpha,
+	int iRedThreshold,
+	int iOrangeThreshold,
+	int iYellowThreshold,
+	int iGreenThreshold,
+	bool bInvert)
 {
-	Color clrResult;
+	Color clrResult = INTENSITYSCALE_COLOR_DEFAULT;
 
-	if( iAmount <= iRed && iColorSetting > 0)
+	if (iColorMode == 0) {
+
+		return Color(
+			clrResult.r(),
+			clrResult.g(),
+			clrResult.b(),
+			iAlpha);
+	}
+
+	bool bSteppedColorMode = iColorMode == 1;
+
+	if (!bInvert && iValue <= iRedThreshold
+		|| bInvert && iValue >= iRedThreshold)
 	{
 		clrResult = INTENSITYSCALE_COLOR_RED;
 	}
-	else if(iAmount  <= iOrange && iColorSetting > 0)
+	else if (!bInvert && iValue <= iOrangeThreshold
+		|| bInvert && iValue >= iOrangeThreshold)
 	{
-		if(iColorSetting == 2)
-			clrResult = ColorFade( iAmount, iRed, iOrange, INTENSITYSCALE_COLOR_RED, INTENSITYSCALE_COLOR_ORANGE );
-		else
-			clrResult = INTENSITYSCALE_COLOR_ORANGE;	
+		clrResult
+			= bSteppedColorMode
+			? INTENSITYSCALE_COLOR_ORANGE
+			: ColorFade(
+				iValue,
+				iRedThreshold,
+				iOrangeThreshold,
+				INTENSITYSCALE_COLOR_RED,
+				INTENSITYSCALE_COLOR_ORANGE,
+				bInvert);
 	}
-	else if(iAmount  <= iYellow && iColorSetting> 0)
+	else if (!bInvert && iValue <= iYellowThreshold
+		|| bInvert && iValue >= iYellowThreshold)
 	{
-		if(iColorSetting == 2)
-			clrResult = ColorFade( iAmount, iOrange, iYellow, INTENSITYSCALE_COLOR_ORANGE, INTENSITYSCALE_COLOR_YELLOW );
-		else
-			clrResult = INTENSITYSCALE_COLOR_YELLOW;
+		clrResult
+			= bSteppedColorMode
+			? INTENSITYSCALE_COLOR_YELLOW
+			: ColorFade(
+				iValue,
+				iOrangeThreshold,
+				iYellowThreshold,
+				INTENSITYSCALE_COLOR_ORANGE,
+				INTENSITYSCALE_COLOR_YELLOW,
+				bInvert);
 	}
-	else if(iColorSetting > 0)
+	else if (!bInvert && iValue <= iGreenThreshold
+		|| bInvert && iValue >= iGreenThreshold)
 	{
-		if(iColorSetting == 2)
-			clrResult = ColorFade( iAmount, iYellow, iGreen, INTENSITYSCALE_COLOR_YELLOW, INTENSITYSCALE_COLOR_GREEN );
-		else
-			clrResult = INTENSITYSCALE_COLOR_GREEN;
-	}
-	else
-	{
-		clrResult = INTENSITYSCALE_COLOR_DEFAULT;
+		clrResult
+			= bSteppedColorMode
+			? INTENSITYSCALE_COLOR_GREEN
+			: ColorFade(
+				iValue,
+				iYellowThreshold,
+				iGreenThreshold,
+				INTENSITYSCALE_COLOR_YELLOW,
+				INTENSITYSCALE_COLOR_GREEN,
+				bInvert);
 	}
 
 	return Color(

--- a/mp/src/game/shared/ff/ff_utils.h
+++ b/mp/src/game/shared/ff/ff_utils.h
@@ -94,9 +94,24 @@ const char *FF_GetDefaultWeapon( int iClassIndex );
 const char *FF_GetDefaultWeapon( const char *classname );
 
 void SetColorByTeam( int iTeam, Color& cColor );
-Color ColorFade( int iValue, int iMin, int iMax, Color clrMin, Color clrMax );
 
-Color GetIntensityColor( int iAmount, int iMaxAmount, int iColorSetting, int iAlpha, int iRed, int iOrange, int iYellow, int iGreen );
+Color ColorFade(
+	int iValue,
+	int iMin,
+	int iMax,
+	Color clrMin,
+	Color clrMax,
+	bool bInvert = false);
+
+Color GetIntensityColor(
+	int iValue,
+	int iColorMode,
+	int iAlpha,
+	int iRedThreshold,
+	int iOrangeThreshold,
+	int iYellowThreshold,
+	int iGreenThreshold,
+	bool bInvert = false);
 
 int FF_NumPlayersOnTeam( int iTeam );
 int FF_GetPlayerOnTeam( int iTeam, int iNum );


### PR DESCRIPTION
Doing this ahead of other HUD changes as I couldn't see wood from trees.  The refactoring makes it easier to make those custom HUD changes.

Main thing to note here is the fix to the average speed display. 

Some idiot (was probably me) wrote an average where it became less an less responsive to the current speed over time.

This new logic has some variables we can tweak to make the average behave differently. I'll make this user-configurable in the new HUD.

This is what is set for now:
```C++
const float dt = 0.1f;     // your m_flNextUpdate step
const float p = 0.8f;      // 80% responsiveness
const float T = 1.0f;      // within 1 second
const float alpha          // 0.14866
	= AlphaForTarget(p, T, dt);
```

Going instantaneously from 0 to 400 speed and remaining at exactly 400. It'll be 80% to 400 within 1 second, and ~100% within 5 seconds.

--- 

See individual commits if you wish to review. Will be easier for you.