### PR TITLE
alias info_ladder and func_null to CNullEntity (info_null)

### DIFF
--- a/mp/src/game/server/subs.cpp
+++ b/mp/src/game/server/subs.cpp
@@ -37,6 +37,20 @@ void CNullEntity::Spawn( void )
 	UTIL_Remove( this );
 }
 LINK_ENTITY_TO_CLASS(info_null,CNullEntity);
+LINK_ENTITY_TO_CLASS(func_null,CNullEntity); // from Mapbase; alias designed for brushes (mainly for invisible texlights)
+
+/*
+info_ladder gets created for each func_ladder by VBSP. It seems to have been intended for navmesh generation.
+However, the entity hasn't existed since 2009 or so; it was replaced with func_simpleladder in L4D, 
+and removed outright in Source SDK 2013 (which FF uses) and CSGO.
+As of this writing, the currently-disabled Omnibot relies upon the entity, but this is a bad idea,
+as ladders can be made out *any* CONTENTS_LADDER brush (or model!), as well as brushes with
+$surfaceprop "ladder" or "woodladder", so func_detail, func_brush, and prop_static ladders are perfectly valid.
+The original info_ladder can be found in the 2006 and 2007 SDKs, in "game/server/nav_ladder.cpp".
+
+To shut up complaints in the console about it not existing, we treat it as an alias for info_null.
+*/
+LINK_ENTITY_TO_CLASS(info_ladder,CNullEntity);
 
 class CBaseDMStart : public CPointEntity
 {


### PR DESCRIPTION
[`info_ladder`](https://developer.valvesoftware.com/wiki/Info_ladder) gets created by VBSP for every func_ladder. Treating it as an alias for info_null shuts up some console spam.

[`func_null`](https://developer.valvesoftware.com/wiki/Func_null) is an alias for info_null in Mapbase. It technically works fine even if it's not defined in-game (I use it in DoD:S a fair amount), but actually having it defined shuts up some console spam.
```c
@SolidClass base(Origin) = func_null : "An alias for info_null. Useful for invisible texlights, such as those appearing to be cast by props or which accentuate the light coming in through a window." 
[
	targetname(target_source) : "Name" : : "Name other entities refer to this entity as. Allows this entity to be used as a prop_static's lighting origin or a spotlight's target."
	vrad_brush_cast_shadows(choices) : "Cast Lightmap Shadows" : "" : "Set this if this brush casts lightmap shadows." =
	[
		"" : "No"
		1 : "Yes"
	]
	vbsp_nobevel(choices) : "No Bevel (VBSP++ only)" : 1 : "If set, bevel faces aren't emitted on angled geometry. This reduces brushsides at the cost of less accurate collision on corners." =
	[
		"" : "Create bevels"
		1 : "No bevels"
	]
]
```

You could also treat [`editor_text`](https://developer.valvesoftware.com/wiki/Editor_text) as an additional alias; I didn't do that because you don't seem to use it. This PR is mainly to shut up the info_ladder console spam.