### PR TITLE
Nail speed

### DIFF
--- a/mp/src/game/shared/ff/projectiles/ff_projectile_nail.cpp
+++ b/mp/src/game/shared/ff/projectiles/ff_projectile_nail.cpp
@@ -26,7 +26,7 @@
 //ConVar ffdev_nail_speed("ffdev_nail_speed", "1000.0", FCVAR_FF_FFDEV_REPLICATED , "Nail speed");
 //ConVar ffdev_nail_pushmultiplier("ffdev_nail_pushmultiplier", "0.05", FCVAR_FF_FFDEV_REPLICATED, "Nail pushforce multiplier - was 0.1 for 2.1 release");
 #define FF_NAIL_PUSHMULTIPLIER 0.05f //ffdev_nail_pushmultiplier.GetFloat()
-#define NAIL_SPEED 1000.0f //ffdev_nail_speed.GetFloat() //2000.0f
+#define NAIL_SPEED 2000.0f //ffdev_nail_speed.GetFloat() //2000.0f and then 1000.0f and now 2000.0f again because 1000 is way too slow
 //ConVar ffdev_nail_bbox("ffdev_nail_bbox", "2.0", FCVAR_FF_FFDEV_REPLICATED, "Nail bbox");
 #define NAIL_BBOX 2.0f
 //ConVar ffdev_nail_sgmod( "ffdev_nail_sgmod", "10.0", FCVAR_FF_FFDEV_REPLICATED, "Added to nail damage when hitting a SG so SG's take more damage" );


### PR DESCRIPTION
Currently, FF's nails have a speed of 1000. This is too slow for nailguns to be effectively used for combat from anything more than close range. You can even exceed the speed of nails using movement tech which feels rather jarring. This change matches their speed to darts fired by the Tranq Gun, which will keep nails still easy to dodge but feeling more effective for fighting. This also gives Scout more capability outside of playing pickup. Projectiles shouldn't be frustrating to use