### PR TITLE
Increase Napalm Duration to 7 Seconds

### DIFF
--- a/mp/src/game/shared/ff/grenades/ff_grenade_napalm.cpp
+++ b/mp/src/game/shared/ff/grenades/ff_grenade_napalm.cpp
@@ -20,7 +20,7 @@
 	#include "particles_simple.h"
 #else
 	//ConVar nap_flame_time("ffdev_nap_flame_time","5.0",FCVAR_FF_FFDEV,"How long the napalm grenade's fires burn");
-	#define NAP_FLAME_TIME 5.0f
+	#define NAP_FLAME_TIME 7.0f
 	//ConVar nap_burn_damage("ffdev_nap_burn_damage","15.0",FCVAR_FF_FFDEV,"How much damage being in the radius of a napalm grenade deals.");
 	#define NAP_BURN_DAMAGE 15.0f
 


### PR DESCRIPTION
Due to Pyro's afterburn being removed from the game, the Napalm Grenade has suffered a loss in power and impact. Its initial use was to cause bursts of large damage and leave afterburn on enemies, but now it is rather unimpactful when one walks through it. To compensate for this loss in power, the Napalm Grenade should last longer in order to have a better chance at inflicting damage levels closer to what it used to be able to. This will also make it feel more impactful during fights, as enemies could possibly spend more time immersed in the flames. The duration has been increased to 7 to standardize it to the effect duration of the Slowfield Grenade.