### PR TITLE
Normal Ragdoll Time returned

### DIFF
--- a/mp/src/game/server/ff/ff_player.cpp
+++ b/mp/src/game/server/ff/ff_player.cpp
@@ -2240,7 +2240,7 @@ void CFFPlayer::CreateRagdollEntity(const CTakeDamageInfo *info)
 		pRagdoll->SetEffectEntity( pRagdollFlame );
 
 		//set the same lifetime the same as the ragdoll itself!
-		pRagdollFlame->SetLifetime( 5.0f );
+		pRagdollFlame->SetLifetime( 15.0f );
 	}
 
 	// not everything that gets here has an info
@@ -2256,7 +2256,7 @@ void CFFPlayer::CreateRagdollEntity(const CTakeDamageInfo *info)
 	}
 
 	// remove the ragdoll after a time
-	pRagdoll->SetNextThink( gpGlobals->curtime + 5.0f );
+	pRagdoll->SetNextThink( gpGlobals->curtime + 15.0f );
 	pRagdoll->SetThink( &CBaseEntity::SUB_Remove );
 
 	// ragdolls will be removed on round restart automatically


### PR DESCRIPTION
As it was in FF before and as it is in any Source game including TF2 right now. Makes Spy Cloak ragdoll more viable and now you can have some fun with the ragdolls after fragging someone