### PR TITLE
Revamped Gas Grenade

### DIFF
--- a/mp/src/game/shared/ff/grenades/ff_grenade_gas.cpp
+++ b/mp/src/game/shared/ff/grenades/ff_grenade_gas.cpp
@@ -168,7 +168,7 @@ PRECACHE_WEAPON_REGISTER( ff_grenade_gas );
 		//}
 
 		// Been detonated for 10 secs now, so fade out
-		if (gpGlobals->curtime > m_flDetonateTime + 10.0f)
+		if (gpGlobals->curtime > m_flDetonateTime + 7.0f)
 		{
 			SetThink(&CBaseGrenade::SUB_FadeOut);
 		}		
@@ -189,7 +189,7 @@ PRECACHE_WEAPON_REGISTER( ff_grenade_gas );
 				m_vecLastPosition = GetAbsOrigin();
 			}
 
-			m_flNextHurt = gpGlobals->curtime + 0.2f;
+			m_flNextHurt = gpGlobals->curtime + 1.0f;
 
 			// If we were idling, deploy
 			if( m_Activity == ACT_GAS_IDLE )
@@ -226,6 +226,9 @@ PRECACHE_WEAPON_REGISTER( ff_grenade_gas );
 					continue;
 
 				pPlayer->Gas(10.0f, 10.0f, pGasser);
+
+				CTakeDamageInfo info(this, pGasser, 5.0f, DMG_DIRECT);
+				pPlayer->TakeDamage(info);
 			}
 		}
 


### PR DESCRIPTION
No more DoT damage, works more in the way it did in older TF games, standing inside the gas grenade deals increased damage to the player but the gassed status itself deals no damage, duration shortened to standardize other area denial grenades that deal damage, but the Gassed Effect still lasts 10 seconds
35 direct damage max, 70 with 2 stacked gas nades