### PR TITLE
Addition to revamped Gas Grenade

### DIFF
--- a/mp/src/game/server/ff/ff_player.cpp
+++ b/mp/src/game/server/ff/ff_player.cpp
@@ -4014,14 +4014,14 @@ void CFFPlayer::StatusEffectsThink( void )
 				CFFPlayer *pGasser = GetGasser();
 				if( pGasser )
 				{
-					CTakeDamageInfo info(pGasser, pGasser, vec3_origin, GetAbsOrigin(), 1.0f, DMG_DIRECT);
+					CTakeDamageInfo info(pGasser, pGasser, vec3_origin, GetAbsOrigin(), 0.0f, DMG_DIRECT); // 1.0f, no more DoT
 					info.SetDamageCustom(DAMAGETYPE_GASSED);
 
 					TakeDamage(info);
 				}
 				else //must be lua set...
 				{
-					CTakeDamageInfo info(this, this, vec3_origin, GetAbsOrigin(), 1.0f, DMG_DIRECT);
+					CTakeDamageInfo info(this, this, vec3_origin, GetAbsOrigin(), 0.0f, DMG_DIRECT); // 1.0f, no more DoT
 					info.SetDamageCustom(DAMAGETYPE_GASSED);
 
 					TakeDamage(info);


### PR DESCRIPTION
No more DoT damage, works more in the way it did in older TF games, standing inside the gas grenade deals increased damage to the player but the gassed status itself deals no damage, duration shortened to standardize other area denial grenades that deal damage, but the Gassed Effect still lasts 10 seconds