### PR TITLE
Movement Patch

### DIFF
--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -61,7 +61,7 @@ ConVar	sv_maxspeed		("sv_maxspeed", "600", FCVAR_NOTIFY | FCVAR_REPLICATED/* | F
 #if defined( CSTRIKE_DLL ) || defined( HL1MP_DLL )
 	ConVar	sv_accelerate	( "sv_accelerate", "10", FCVAR_NOTIFY | FCVAR_REPLICATED);
 #else
-	ConVar	sv_accelerate	( "sv_accelerate", "14", FCVAR_NOTIFY | FCVAR_REPLICATED/* | FCVAR_DEVELOPMENTONLY*/);
+	ConVar	sv_accelerate	( "sv_accelerate", "10", FCVAR_NOTIFY | FCVAR_REPLICATED/* | FCVAR_DEVELOPMENTONLY*/);
 #endif // CSTRIKE_DLL
 	
 #endif//_XBOX


### PR DESCRIPTION
Makes SSG and NG/SNG duels more fair as you can read and predict the movement without instant strafes right after the counterstrafes, default value of Quake 1, Quake 3, TFC and TF2, does not affect anything except onground movement