### PR TITLE
Caps increased

### DIFF
--- a/mp/src/game/shared/ff/ff_shareddefs.h
+++ b/mp/src/game/shared/ff/ff_shareddefs.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:
 //
@@ -147,9 +147,9 @@ struct SpyDisguiseWeapon
 #define DECAP_LEFT_LEG		( 1 << 3 )
 #define DECAP_RIGHT_LEG		( 1 << 4 )
 
-#define BHOP_CAP_SOFT 1.4f
-#define BHOP_CAP_MID 1.55f
-#define BHOP_CAP_HARD 1.71f
+#define BHOP_CAP_SOFT 1.7f
+#define BHOP_CAP_MID 1.875f
+#define BHOP_CAP_HARD 2.0f
 #define BHOP_PCFACTOR 0.65f
 #define BHOP_PCFACTOR_MID 0.4f
 


### PR DESCRIPTION
FF Caps were lower than TFC caps that is considered pretty slow classic tf bc of its caps, now FF goes above that, and makes defensive classes more viable on offense (like qwtf and its forks)
1.875 Cap gives us
230 - [430] 431.25 (round numbers were not the part of current ff speed cap list too)
240 - 450
280 -  525
300 - [560] 562.5
320 -  600
400 - 750
