### PR TITLE
Fixed MIRV static roll that depends on the world to more natural one

### DIFF
--- a/mp/src/game/shared/ff/grenades/ff_grenade_mirv.cpp
+++ b/mp/src/game/shared/ff/grenades/ff_grenade_mirv.cpp
@@ -60,6 +60,7 @@ public:
 	CFFGrenadeMirv( const CFFGrenadeMirv& ) {}
 #else
 	virtual void Spawn();
+	virtual void GrenadeThink();
 	virtual void Explode( trace_t *pTrace, int bitsDamageType );
 	virtual float GetGrenadeDamage()		{ return MIRV_DMG; }
 	virtual float GetGrenadeRadius()		{ return MIRV_RADIUS; }
@@ -84,7 +85,29 @@ void CFFGrenadeMirv::Spawn( void )
 	SetModel( MIRVGRENADE_MODEL );
 	BaseClass::Spawn();
 
-	SetLocalAngularVelocity(QAngle(0, RandomFloat(-5, 5), 0));
+	SetThink(&CFFGrenadeMirv::GrenadeThink);
+	SetNextThink(gpGlobals->curtime);
+}
+
+//------------------------------------------------------------------------------
+// Purpose: No Y and Z roll
+//------------------------------------------------------------------------------
+void CFFGrenadeMirv::GrenadeThink()
+{
+	IPhysicsObject* pPhys = VPhysicsGetObject();
+
+	if (pPhys)
+	{
+		AngularImpulse angVel(0, 0, 0);
+		pPhys->SetVelocityInstantaneous(NULL, &angVel);
+	}
+
+	QAngle ang = GetAbsAngles();
+	ang.x = 0.0f;
+	ang.z = 0.0f;
+	SetAbsAngles(ang);
+
+	BaseClass::GrenadeThink();
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/shared/ff/grenades/ff_grenade_mirv.cpp
+++ b/mp/src/game/shared/ff/grenades/ff_grenade_mirv.cpp
@@ -94,14 +94,6 @@ void CFFGrenadeMirv::Spawn( void )
 //------------------------------------------------------------------------------
 void CFFGrenadeMirv::GrenadeThink()
 {
-	IPhysicsObject* pPhys = VPhysicsGetObject();
-
-	if (pPhys)
-	{
-		AngularImpulse angVel(0, 0, 0);
-		pPhys->SetVelocityInstantaneous(NULL, &angVel);
-	}
-
 	QAngle ang = GetAbsAngles();
 	ang.x = 0.0f;
 	ang.z = 0.0f;


### PR DESCRIPTION
Make it have no Y and Z roll instead of fully blocking its roll with SetLocalAngularVelocity(QAngle(0, RandomFloat(-5, 5), 0));