### PR TITLE
Ammo Discard Options

### DIFF
--- a/mp/src/game/server/ff/ff_player.cpp
+++ b/mp/src/game/server/ff/ff_player.cpp
@@ -4003,6 +4003,116 @@ void CFFPlayer::Command_Discard(const CCommand& args)
 	}
 }
 
+static void DiscardBackpack(CFFPlayer* pPlayer,
+	int iShells, int iNails, int iCells, int iRockets)
+{
+	if (!pPlayer)
+		return;
+
+	iShells = min(iShells, pPlayer->GetAmmoCount(AMMO_SHELLS));
+	iNails = min(iNails, pPlayer->GetAmmoCount(AMMO_NAILS));
+	iCells = min(iCells, pPlayer->GetAmmoCount(AMMO_CELLS));
+	iRockets = min(iRockets, pPlayer->GetAmmoCount(AMMO_ROCKETS));
+
+	if (iShells <= 0 && iNails <= 0 && iCells <= 0 && iRockets <= 0)
+		return;
+
+	CFFItemBackpack* pBackpack = (CFFItemBackpack*)CBaseEntity::Create(
+		"ff_item_backpack", pPlayer->GetAbsOrigin(), pPlayer->GetAbsAngles());
+
+	if (!pBackpack)
+		return;
+
+	pBackpack->SetSpawnFlags(SF_NORESPAWN);
+	pBackpack->SetOwnerEntity(pPlayer);
+	pBackpack->m_bIsDeathBag = false;
+
+	if (iShells > 0) pBackpack->SetAmmoCount(GetAmmoDef()->Index(AMMO_SHELLS), iShells);
+	if (iNails > 0) pBackpack->SetAmmoCount(GetAmmoDef()->Index(AMMO_NAILS), iNails);
+	if (iCells > 0) pBackpack->SetAmmoCount(GetAmmoDef()->Index(AMMO_CELLS), iCells);
+	if (iRockets > 0) pBackpack->SetAmmoCount(GetAmmoDef()->Index(AMMO_ROCKETS), iRockets);
+
+	bool bDiscardAllowed = true;
+	CFFLuaSC hContext(0);
+	hContext.Push(pPlayer);
+	hContext.Push(pBackpack);
+	hContext.Push(pBackpack->m_bIsDeathBag);
+	if (_scriptman.RunPredicates_LUA(NULL, &hContext, "player_ondiscard"))
+		bDiscardAllowed = hContext.GetBool();
+
+	if (!bDiscardAllowed)
+	{
+		UTIL_Remove(pBackpack);
+		return;
+	}
+
+	if (iShells > 0) pPlayer->RemoveAmmo(iShells, AMMO_SHELLS);
+	if (iNails > 0) pPlayer->RemoveAmmo(iNails, AMMO_NAILS);
+	if (iCells > 0) pPlayer->RemoveAmmo(iCells, AMMO_CELLS);
+	if (iRockets > 0) pPlayer->RemoveAmmo(iRockets, AMMO_ROCKETS);
+
+	Vector vForward;
+	AngleVectors(pPlayer->EyeAngles(), &vForward);
+	vForward *= 420.0f;
+	if (vForward.z < 1.0f)
+		vForward.z = 1.0f;
+
+	pBackpack->SetAbsVelocity(vForward);
+	pBackpack->SetAbsOrigin(pPlayer->GetAbsOrigin());
+	pPlayer->EmitSound("Item.Toss");
+}
+
+void CFFPlayer::Command_DiscardUnneeded(const CCommand& args)
+{
+	bool bKeepAmmo[MAX_AMMO_TYPES] = { false };
+	for (int i = 0; i < MAX_WEAPON_SLOTS; i++)
+	{
+		if (GetWeapon(i))
+		{
+			int ammoid = GetWeapon(i)->GetPrimaryAmmoType();
+			if (ammoid > -1)
+				bKeepAmmo[ammoid] = true;
+		}
+	}
+	int iShells = bKeepAmmo[GetAmmoDef()->Index(AMMO_SHELLS)] ? 0 : GetAmmoCount(AMMO_SHELLS);
+	int iNails = bKeepAmmo[GetAmmoDef()->Index(AMMO_NAILS)] ? 0 : GetAmmoCount(AMMO_NAILS);
+	int iRockets = bKeepAmmo[GetAmmoDef()->Index(AMMO_ROCKETS)] ? 0 : GetAmmoCount(AMMO_ROCKETS);
+	int iCells = bKeepAmmo[GetAmmoDef()->Index(AMMO_CELLS)] ? 0 : GetAmmoCount(AMMO_CELLS);
+	DiscardBackpack(this, iShells, iNails, iRockets, iCells);
+}
+void CFFPlayer::Command_DiscardHalfShells(const CCommand& args)
+{
+	DiscardBackpack(this, GetAmmoCount(AMMO_SHELLS) / 2, 0, 0, 0);
+}
+void CFFPlayer::Command_DiscardHalfNails(const CCommand& args)
+{
+	DiscardBackpack(this, 0, GetAmmoCount(AMMO_NAILS) / 2, 0, 0);
+}
+void CFFPlayer::Command_DiscardHalfRockets(const CCommand& args)
+{
+	DiscardBackpack(this, 0, 0, 0, GetAmmoCount(AMMO_ROCKETS) / 2);
+}
+void CFFPlayer::Command_DiscardHalfCells(const CCommand& args)
+{
+	DiscardBackpack(this, 0, 0, GetAmmoCount(AMMO_CELLS) / 2, 0);
+}
+void CFFPlayer::Command_DiscardAllShells(const CCommand& args)
+{
+	DiscardBackpack(this, GetAmmoCount(AMMO_SHELLS), 0, 0, 0);
+}
+void CFFPlayer::Command_DiscardAllNails(const CCommand& args)
+{
+	DiscardBackpack(this, 0, GetAmmoCount(AMMO_NAILS), 0, 0);
+}
+void CFFPlayer::Command_DiscardAllRockets(const CCommand& args)
+{
+	DiscardBackpack(this, 0, 0, 0, GetAmmoCount(AMMO_ROCKETS));
+}
+void CFFPlayer::Command_DiscardAllCells(const CCommand& args)
+{
+	DiscardBackpack(this, 0, 0, GetAmmoCount(AMMO_CELLS), 0);
+}
+
 void CFFPlayer::StatusEffectsThink( void )
 {
 	if( m_bGassed )

--- a/mp/src/game/server/ff/ff_player.h
+++ b/mp/src/game/server/ff/ff_player.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose:		Player for FF Game
 //
@@ -351,6 +351,15 @@ public:
 	void Command_DropItems(const CCommand& args = CCommand());
 	void Command_DetPipes(const CCommand& args = CCommand());
 	void Command_Discard(const CCommand& args = CCommand());
+	void Command_DiscardUnneeded(const CCommand& args = CCommand());
+	void Command_DiscardHalfShells(const CCommand& args = CCommand());
+	void Command_DiscardHalfNails(const CCommand& args = CCommand());
+	void Command_DiscardHalfRockets(const CCommand& args = CCommand());
+	void Command_DiscardHalfCells(const CCommand& args = CCommand());
+	void Command_DiscardAllShells(const CCommand& args = CCommand());
+	void Command_DiscardAllNails(const CCommand& args = CCommand());
+	void Command_DiscardAllRockets(const CCommand& args = CCommand());
+	void Command_DiscardAllCells(const CCommand& args = CCommand());
 	void Command_SaveMe(const CCommand& args = CCommand());
 	void Command_EngyMe(const CCommand& args = CCommand());
 	void Command_AmmoMe(const CCommand& args = CCommand());

--- a/mp/src/game/shared/ff/ff_playercommand.cpp
+++ b/mp/src/game/shared/ff/ff_playercommand.cpp
@@ -147,6 +147,15 @@ FF_AUTO_COMMAND( dispensertext, &CFFPlayer::Command_DispenserText, "Set custom t
 FF_AUTO_COMMAND( detpack, &CFFPlayer::Command_BuildDetpack, "Drop a detpack.", FF_CMD_SKILL_COMMAND | FF_CMD_ALIVE | FF_CMD_PREMATCH );
 FF_AUTO_COMMAND( mancannon, &CFFPlayer::Command_BuildManCannon, "Build a man cannon.", FF_CMD_SKILL_COMMAND | FF_CMD_ALIVE | FF_CMD_PREMATCH );
 FF_AUTO_COMMAND( discard, &CFFPlayer::Command_Discard, "Discards unneeded ammo", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardunneeded, &CFFPlayer::Command_DiscardUnneeded, "Discard unneeded ammo", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardhalfshells, &CFFPlayer::Command_DiscardHalfShells, "Discard half the shells", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardhalfnails, &CFFPlayer::Command_DiscardHalfNails, "Discard half the nails", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardhalfrockets, &CFFPlayer::Command_DiscardHalfRockets, "Discard half the rockets", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardhalfcells, &CFFPlayer::Command_DiscardHalfCells, "Discard half the cells", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardallshells, &CFFPlayer::Command_DiscardAllShells, "Discard all the shells", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardallnails, &CFFPlayer::Command_DiscardAllNails, "Discard all the nails", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardallrockets, &CFFPlayer::Command_DiscardAllRockets, "Discard all the rockets", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
+FF_AUTO_COMMAND( discardallcells, &CFFPlayer::Command_DiscardAllCells, "Discard all the cells", FF_CMD_ALIVE | FF_CMD_PREMATCH | FF_CMD_CLOAKED );
 FF_SHARED_COMMAND( saveme, &CFFPlayer::Command_SaveMe, CC_SaveMe, "Call for medical attention", FF_CMD_ALIVE | FF_CMD_PREMATCH );
 FF_SHARED_COMMAND( engyme, &CFFPlayer::Command_EngyMe, CC_EngyMe, "Call for engineer attention", FF_CMD_ALIVE | FF_CMD_PREMATCH );
 FF_SHARED_COMMAND( ammome, &CFFPlayer::Command_AmmoMe, CC_AmmoMe, "Call for ammo", FF_CMD_ALIVE | FF_CMD_PREMATCH );


### PR DESCRIPTION
Now Soldiers can drop Rockets and Pyros can drop Cells and so on
The small issue is that i replicated "discardunneeded" to work the same way as default "discard" so here we kinda have 2 commands that do the same so i suppose default "discard" could be cut OR the circle menu of ammo discarding could be summoned by "discard" command rather than making "discardmenu" as a separate command or something