### PR TITLE
Modernise constructors for improved performance

### DIFF
--- a/mp/src/game/server/ff/ff_player.h
+++ b/mp/src/game/server/ff/ff_player.h
@@ -108,10 +108,10 @@ struct RecentAttackerInfo
 	float timestamp;
 
 	RecentAttackerInfo(CFFPlayer *pPlayer, float dmg, float ts)
+		: hPlayer(pPlayer)
+		, totalDamage(dmg)
+		, timestamp(ts)
 	{
-		hPlayer = pPlayer;
-		totalDamage = dmg;
-		timestamp = ts;
 	}
 
 	/* debugging

--- a/mp/src/game/server/ff/lua/ff_lualib_globals.cpp
+++ b/mp/src/game/server/ff/lua/ff_lualib_globals.cpp
@@ -113,19 +113,19 @@ class CHudBoxBorder
 {
 public:
 	CHudBoxBorder()
+		: clr()
+		, width(0)
 	{
-		clr = Color();
-		width = 0;
 	}
 	CHudBoxBorder(Color _clr)
+		: clr(_clr)
+		, width(1)
 	{
-		clr = _clr;
-		width = 1;
 	}
 	CHudBoxBorder(Color _clr, int _width)
+		: clr(_clr)
+		, width(_width)
 	{
-		clr = _clr;
-		width = _width;
 	}
 
 public:

--- a/mp/src/game/shared/ff/ff_playercommand.cpp
+++ b/mp/src/game/shared/ff/ff_playercommand.cpp
@@ -25,13 +25,9 @@
 // instance is actually created inside the first FF_AUTOLINK_COMMAND macro on the server
 CPlayerCommands *g_pPlayerCommands = NULL;
 
-CPlayerCommands::CPlayerCommands(void)
-{
-}
+CPlayerCommands::CPlayerCommands(void) = default;
 
-CPlayerCommands::~CPlayerCommands(void)
-{
-}
+CPlayerCommands::~CPlayerCommands(void) = default;
 
 void CPlayerCommands::RegisterCommand(CPlayerCommand *pNewCmd)
 {
@@ -41,7 +37,7 @@ void CPlayerCommands::RegisterCommand(CPlayerCommand *pNewCmd)
 		return;
 	}
 
-	m_mapPlayerCommands.insert(std::make_pair(pNewCmd->m_strCommand, pNewCmd));
+	m_mapPlayerCommands.emplace(pNewCmd->m_strCommand, pNewCmd);
 }
 
 // returns true if command was sent to run on the player's object
@@ -122,11 +118,10 @@ bool CPlayerCommands::ProcessCommand(CBaseEntity *pEntity, const CCommand& args)
 }
 
 CPlayerCommand::CPlayerCommand(std::string strCommand, PLAYERCMD_FUNC_TYPE pfn, unsigned int uiFlags)
+	: m_strCommand(std::move(strCommand))
+	, m_pfn(pfn)
+	, m_uiFlags(uiFlags)
 {
-	m_strCommand = strCommand;
-	m_pfn = pfn;
-	m_uiFlags = uiFlags;
-
 	if(g_pPlayerCommands == NULL)
 		g_pPlayerCommands = new CPlayerCommands;
 

--- a/mp/src/game/shared/ff/grenades/ff_grenade_nail.cpp
+++ b/mp/src/game/shared/ff/grenades/ff_grenade_nail.cpp
@@ -74,9 +74,9 @@ class PseudoNail
 	// Purpose: Constructor -- only the position and angle are unique for each nail
 	//-------------------------------------------------------------------------------------------------------
 		PseudoNail( const Vector &vOrigin, const QAngle &vAngles )
+			: m_vecOrigin( vOrigin )
+			, m_vecAngles( vAngles )
 		{
-			m_vecOrigin = vOrigin;
-			m_vecAngles = vAngles;
 		}
 
 	//-------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This will enhance the performance of the FF 2013 server by replacing the assignment operators. But the results won't be very significant, as there's still a long way to go before pushing the FF 2013 server's speed to the limit.